### PR TITLE
Draft minimal ini-grammar

### DIFF
--- a/src/ini.pest
+++ b/src/ini.pest
@@ -1,13 +1,10 @@
-WHITESPACE = _{ " " }
-char = { ASCII_ALPHANUMERIC | "." | "_" | "/" }
-name = @{ char+ }
-value = @{ char* }
+ini = { SOI ~ (section | pair | comment)* ~ EOI }
 
-section = { "[" ~ name ~ "]" }
-property = { name ~ "=" ~ value }
+section = { "[" ~ key ~ "]" }
+pair = { key ~ "=" ~ value }
+comment = { (";" | "#" ~ value }
 
-file = {
-	SOI ~
-	((section | property)? ~ NEWLINE)* ~
-	EOI
-}
+key = @{ (!("]" | "=" | WHITESPACE) ~ ANY)+ }
+value = @{ (!(NEWLINE) ~ ANY)+ }
+
+WHITESPACE = _{ " " | "\t" | NEWLINE }


### PR DESCRIPTION
The minimal ini-grammar aims to be a human readable specification of the INI-format.

It should be used to create a referential INI-AST which is only valid in conjunction with the parsed file.

---

## Current Features

- Comment lines beginning with `;` or `#`
- Section headers and property-keys consisting of every character except from  `]` and `=`
- Perperty-values conisting of every character except from a `NEWLINE`